### PR TITLE
embedded table: use DOMAIN to look up the resource fields

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -391,9 +391,26 @@ change in your `settings.py`:
         'people': People._eve_schema['people'],
     }
 
+Embedded resources
+------------------
+
+Eve-SQLAlchemy support the embedded keyword of python-eve ( `Eve Embedded Resource Serialization`_ ).
+
+.. code-block:: console
+
+    http://127.0.0.1:5000/people?embedded={"address":1}
+
+For example, the following request will list the people and embedded their addresses.
+
+Starting from version 0.3.5, only the fields that have the projection (`Eve Projections`) enabled are included
+in the associated resource. This was necessary to avoid endless loop when relationship between resources were
+refeering each others.
+
 
 .. _SQLAlchemy: http://www.sqlalchemy.org/
 .. _Flask-SQLAlchemy: http://flask-sqlalchemy.pocoo.org/
 .. _SQLAlchemy internals: http://docs.sqlalchemy.org/en/latest/orm/internals.html
 .. _SQLAlchemy ORDER BY: http://docs.sqlalchemy.org/en/latest/core/sqlelement.html#sqlalchemy.sql.expression.nullsfirst
 .. _`Eve Authentication`: http://python-eve.org/authentication.html#token-based-authentication
+.. _`Eve Embedded Resource Serialization`: http://python-eve.org/features.html#embedded-resource-serialization
+.. _`Eve Projections`: http://python-eve.org/features.html#projections

--- a/eve_sqlalchemy/__init__.py
+++ b/eve_sqlalchemy/__init__.py
@@ -106,7 +106,8 @@ class SQL(DataLayer):
         :param req: a :class:`ParsedRequest`instance.
         :param sub_resource_lookup: sub-resource lookup from the endpoint url.
         """
-        args = {'sort': extract_sort_arg(req)}
+        args = {'sort': extract_sort_arg(req),
+                'resource': resource}
 
         client_projection = self._client_projection(req)
         client_embedded = self._client_embedded(req)

--- a/eve_sqlalchemy/structures.py
+++ b/eve_sqlalchemy/structures.py
@@ -31,6 +31,7 @@ class SQLAResultCollection(object):
         self._sort = kwargs.get('sort')
         self._max_results = kwargs.get('max_results')
         self._page = kwargs.get('page')
+        self._resource = kwargs.get('resource')
         if self._spec:
             self._query = self._query.filter(*self._spec)
         if self._sort:

--- a/eve_sqlalchemy/tests/delete.py
+++ b/eve_sqlalchemy/tests/delete.py
@@ -124,8 +124,8 @@ class TestDeleteSQL(TestBaseSQL):
         # verify that the only document retrieved is referencing the correct
         # parent document
         response, status = self.get('users/%s/invoices' % fake_person_id)
-        person_id = response[self.app.config['ITEMS']][1]['people']
-        self.assertEqual(person_id['_id'], fake_person_id)
+        person_id = response[self.app.config['ITEMS']][1]['people_id']
+        self.assertEqual(person_id, fake_person_id)
 
         # delete all documents at the sub-resource endpoint
         response, status = self.delete('users/%s/invoices' % fake_person_id)

--- a/eve_sqlalchemy/tests/sql.py
+++ b/eve_sqlalchemy/tests/sql.py
@@ -186,11 +186,12 @@ class TestSQLStructures(TestCase):
 
     def test_sql_collection_pagination(self):
         self.setupDB()
-        c = SQLAResultCollection(self.query, self.fields,
-                                 max_results=self.max_results)
-        self.assertEqual(c.count(), self.known_resource_count)
-        results = [p for p in c]
-        self.assertEqual(len(results), self.max_results)
+        with self.app.app_context():
+            c = SQLAResultCollection(self.query, self.fields,
+                                     max_results=self.max_results)
+            self.assertEqual(c.count(), self.known_resource_count)
+            results = [p for p in c]
+            self.assertEqual(len(results), self.max_results)
         self.dropDB()
 
     def test_base_sorting(self):

--- a/eve_sqlalchemy/tests/test_settings_sql.py
+++ b/eve_sqlalchemy/tests/test_settings_sql.py
@@ -24,8 +24,13 @@ people = {'item_title': 'person',
           },
           'cache_control': 'max-age=10,must-revalidate',
           'cache_expires': 10,
-          'resource_methods': ['GET', 'POST', 'DELETE']
-          }
+          'resource_methods': ['GET', 'POST', 'DELETE'],
+          'schema': {
+              'invoices_collection': {
+                  'type': 'objectid',
+                  'data_relation': {
+                      'embeddable': True,
+                      'resource': 'invoices'}}}}
 
 import copy
 users = copy.deepcopy(people)

--- a/eve_sqlalchemy/tests/test_sql_tables.py
+++ b/eve_sqlalchemy/tests/test_sql_tables.py
@@ -58,7 +58,7 @@ class Invoices(CommonColumns):
     __tablename__ = 'invoices'
     number = Column(Integer)
     people_id = Column(Integer, ForeignKey('people._id'))
-    people = relationship(People)
+    people = relationship(People, backref='invoices_collection')
 
 
 @registerSchema('payments')

--- a/eve_sqlalchemy/utils.py
+++ b/eve_sqlalchemy/utils.py
@@ -59,23 +59,12 @@ def sqla_object_to_dict(obj, fields):
             # response.
             if getattr(val, 'copy', None) is not None:
                 val = val.copy()
-
             # is this field another SQLalchemy object, or a list of SQLalchemy objects?
             if isinstance(val.__class__, DeclarativeMeta):
-                if field in config.DOMAIN:
-                    # we have embedded document in schema, let's resolve it:
-                    result[field] = sqla_object_to_dict(val, list(config.DOMAIN[field]['schema'].keys()))
-                else:
-                    result[field] = getattr(val, config.ID_FIELD)
-
+                result[field] = getattr(val, config.ID_FIELD)
             elif isinstance(val, list) and len(val) > 0 \
                     and isinstance(val[0].__class__, DeclarativeMeta):
-                if field in config.DOMAIN:
-                    # we have embedded document in schema, let's resolve it:
-                    result[field] = [sqla_object_to_dict(x, list(config.DOMAIN[field]['schema'].keys())) for x in val]
-                else:
-                    result[field] = [getattr(x, config.ID_FIELD) for x in val]
-
+                result[field] = [getattr(x, config.ID_FIELD) for x in val]
             else:
                 # If integral type, just copy it
                 result[field] = copy.copy(val)


### PR DESCRIPTION
This patch resolve two issues:
- it's now possible to have a resource field that is a relation to
  another relation, even if the name doesn't match. For example,
  product_stable and product_devel are two one-to-one field with a
  relationship to product
- when we associate a foreign resource, we let
  eve.utils.embedded_document() decide what field should be import in
  the embedded resource. Previously, all the fields of the embedded
  resource were imported, with the thread of potential endless loops.
  For example, a any-to-one relation called
  `foo` with an associate to `bar` that we pull with embedded.
  `bar` has got a `foo_collection` with a link to `foo`. Previously, the
  `foo_collection` filed was automatically added in the list of field of `bar`.
  This was enough to create a resource loop in `lookup_foreign_resource`.
- eve.utils.embedded_document() was confused because it was try to
  resolve itself embedded resource that were already pulled by
  eve_sqlalchemy.utils.sqla_object_to_dict(). Because of that, all the
  embedd resources were prefixed with a ID_FIELD in the final JSON.
  We now only retrieve the ID_FIELD value, as expected by
  embedded_document()
- the patch, with https://github.com/nicolaiarocci/eve/pull/656 will allow
  the use of sub-embedded document
