### PR TITLE
Limit scope of flake8 in tox to project source code

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands = py.test {posargs}
 
 [testenv:flake8]
 deps = flake8
-commands = flake8 .
+commands = flake8 eve_sqlalchemy examples *.py
 
 [testenv:isort]
 deps = isort


### PR DESCRIPTION
Otherwise includes stuff in .eggs  which is not relevant