### PR TITLE
adding media type support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ Scripts
 
 #pyenv
 .python-version
+.venv
 
 #OSX
 .Python
@@ -65,3 +66,6 @@ _build
 .idea
 
 .cache
+
+# vscode
+.vscode

--- a/eve_sqlalchemy/config/fieldconfig.py
+++ b/eve_sqlalchemy/config/fieldconfig.py
@@ -56,7 +56,7 @@ class ColumnFieldConfig(FieldConfig):
     def _get_field_nullable(self):
         return getattr(self._sqla_column, 'nullable', True)
 
-    def has_server_default(self):
+    def _has_server_default(self):
         return bool(getattr(self._sqla_column, 'server_default'))
 
     def _get_field_required(self):
@@ -65,7 +65,7 @@ class ColumnFieldConfig(FieldConfig):
                          and isinstance(self._sqla_column.type, types.Integer))
         return not (self._get_field_nullable()
                     or autoincrement
-                    or self.has_server_default())
+                    or self._has_server_default())
 
     def _get_field_unique(self):
         return getattr(self._sqla_column, 'unique', None)

--- a/eve_sqlalchemy/config/fieldconfig.py
+++ b/eve_sqlalchemy/config/fieldconfig.py
@@ -56,11 +56,16 @@ class ColumnFieldConfig(FieldConfig):
     def _get_field_nullable(self):
         return getattr(self._sqla_column, 'nullable', True)
 
+    def has_server_default(self):
+        return bool(getattr(self._sqla_column, 'server_default'))
+
     def _get_field_required(self):
         autoincrement = (self._sqla_column.primary_key
                          and self._sqla_column.autoincrement
                          and isinstance(self._sqla_column.type, types.Integer))
-        return not (self._get_field_nullable() or autoincrement)
+        return not (self._get_field_nullable()
+                    or autoincrement
+                    or self.has_server_default())
 
     def _get_field_unique(self):
         return getattr(self._sqla_column, 'unique', None)

--- a/eve_sqlalchemy/tests/config/resourceconfig/schema.py
+++ b/eve_sqlalchemy/tests/config/resourceconfig/schema.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import sqlalchemy as sa
 import sqlalchemy.dialects.postgresql as postgresql
 from sqlalchemy import Column, types
 from sqlalchemy.ext.declarative import declarative_base
@@ -22,6 +23,7 @@ class SomeModel(Base):
     a_pickle = Column(types.PickleType)
     a_string = Column(types.String(42), default='H2G2')
     _internal = Column(types.Integer)
+    a_server_default_col = Column(types.Integer, server_default=sa.text('0'))
 
 
 class StringPK(Base):
@@ -39,7 +41,7 @@ class TestSchema(ResourceConfigTestCase):
         self.assertEqual(set(schema.keys()),
                          set(('id', 'a_boolean', 'a_date', 'a_datetime',
                               'a_float', 'a_json', 'another_json',
-                              'a_pickle', 'a_string')))
+                              'a_pickle', 'a_string', 'a_server_default_col')))
 
     def test_field_types(self):
         schema = self._render(SomeModel)['schema']
@@ -66,6 +68,7 @@ class TestSchema(ResourceConfigTestCase):
         # autoincrement='auto' per default (see SQLAlchemy docs for
         # details). As such, it is not required.
         self.assertFalse(schema['id']['required'])
+        self.assertFalse(schema['a_server_default_col']['required'])
 
     def test_required_string_pk(self):
         schema = self._render(StringPK)['schema']

--- a/eve_sqlalchemy/tests/test_validation.py
+++ b/eve_sqlalchemy/tests/test_validation.py
@@ -15,6 +15,9 @@ class TestValidator(unittest.TestCase):
             'a_objectid': {
                 'type': 'objectid',
             },
+            'a_media': {
+                'type': 'media',
+            }
         }
         self.validator = eve_sqlalchemy.validation.ValidatorSQL(schemas)
 
@@ -25,3 +28,13 @@ class TestValidator(unittest.TestCase):
     def test_type_objectid(self):
         self.validator.validate_update(
             {'a_objectid': ''}, None)
+
+    def test_type_media(self):
+        from werkzeug.datastructures import FileStorage
+
+        self.assertFalse(self.validator.validate(
+            {'a_media': 100}    # check if integer type data passes through
+        ))
+        self.assertTrue(self.validator.validate(
+            {'a_media': FileStorage(filename=__file__)}
+        ))

--- a/eve_sqlalchemy/validation.py
+++ b/eve_sqlalchemy/validation.py
@@ -20,6 +20,7 @@ from eve.versioning import (
     get_data_version_relation_document, missing_version_field,
 )
 from flask import current_app as app
+from werkzeug.datastructures import FileStorage
 
 from eve_sqlalchemy.utils import dict_update, remove_none_values
 
@@ -117,6 +118,15 @@ class ValidatorSQL(Validator):
         :param value: field value.
         """
         pass
+
+    def _validate_type_media(self, field, value):
+        """Enable validation for `media` type schema.
+
+        :param field: field name.
+        :param value: field value.
+        """
+        if not isinstance(value, FileStorage):
+            self._error(field, "File was expected, got '%s' instead." % value)
 
     def _validate_readonly(self, read_only, field, value):
         # Copied from eve/io/mongo/validation.py.


### PR DESCRIPTION
as `Eve` documentation says it supports uploading media/files by `media` type. this commit is just following the example at [http://python-eve.org/features.html#file-storage](http://python-eve.org/features.html#file-storage). One test is added for checking the validity of it.