### PR TITLE
Eve 0.7 support

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ Changelog
 0.7.0 (unreleased)
 ~~~~~~~~~~~~~~~~~~
 
-- Nothing changed yet.
+- Eve 0.7 support (#178) [Nicola Iarocci]
 
 
 0.6.0 (2018-08-15)

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -2,6 +2,13 @@
 Upgrading
 =========
 
+Upgrading from 0.6.0 to 0.7.0
+=============================
+
+With Eve v0.7, the ETag format was changed to comply with RFC 7232-2.3. Be
+aware the ETag header values are now enclosed with double-quotes.
+
+
 Upgrading from 0.5.0 to 0.6.0
 =============================
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -5,9 +5,17 @@ Upgrading
 Upgrading from 0.6.0 to 0.7.0
 =============================
 
-With Eve v0.7, the ETag format was changed to comply with RFC 7232-2.3. Be
-aware the ETag header values are now enclosed with double-quotes.
+Eve-SQLAlchemy is now based on Eve 0.7, which introduces potentially breaking
+changes:
 
+- The ETag format was changed to comply with RFC 7232-2.3. Be aware the ETag
+  header values are now enclosed with double-quotes.
+- Eve now returns a `428 Precondition Required` instead of a generic `403
+  Forbidden` when the `If-Match` request header is missing.
+
+For a comprehensive list of changes refer to the `official changelog`_.
+
+.. _official changelog: http://python-eve.org/changelog.html#version-0-7
 
 Upgrading from 0.5.0 to 0.6.0
 =============================

--- a/eve_sqlalchemy/tests/get.py
+++ b/eve_sqlalchemy/tests/get.py
@@ -13,6 +13,18 @@ from eve_sqlalchemy.tests import TestBase
 class TestGet(eve_get_tests.TestGet, TestBase):
 
     @pytest.mark.xfail(True, run=False, reason='not applicable to SQLAlchemy')
+    def test_get_aggregation_parsing(self):
+        pass
+
+    @pytest.mark.xfail(True, run=False, reason='not applicable to SQLAlchemy')
+    def test_get_aggregation_pagination(self):
+        pass
+
+    @pytest.mark.xfail(True, run=False, reason='not applicable to SQLAlchemy')
+    def test_get_aggregation_endpoint(self):
+        pass
+
+    @pytest.mark.xfail(True, run=False, reason='not applicable to SQLAlchemy')
     def test_get_where_mongo_combined_date(self):
         pass
 
@@ -58,6 +70,10 @@ class TestGet(eve_get_tests.TestGet, TestBase):
 
     @pytest.mark.xfail(True, run=False, reason='not implemented yet')
     def test_get_embedded_media(self):
+        pass
+
+    @pytest.mark.xfail(True, run=False, reason='not implemented yet')
+    def test_get_embedded_media_validate_rest_of_fields(self):
         pass
 
     def test_get_embedded(self):

--- a/eve_sqlalchemy/tests/post.py
+++ b/eve_sqlalchemy/tests/post.py
@@ -10,6 +10,22 @@ from eve_sqlalchemy.tests import TestBase, test_sql_tables
 
 class TestPost(eve_post_tests.TestPost, TestBase):
 
+    @pytest.mark.xfail(True, run=False, reason='not applicable to SQLAlchemy')
+    def test_post_auto_create_lists(self):
+        pass
+
+    @pytest.mark.xfail(True, run=False, reason='not applicable to SQLAlchemy')
+    def test_post_auto_collapse_multiple_keys(self):
+        pass
+
+    @pytest.mark.xfail(True, run=False, reason='not applicable to SQLAlchemy')
+    def test_post_auto_collapse_media_list(self):
+        pass
+
+    @pytest.mark.xfail(True, run=False, reason='not applicable to SQLAlchemy')
+    def test_dbref_post_referential_integrity(self):
+        pass
+
     @pytest.mark.xfail(True, run=False, reason='not implemented yet')
     def test_post_duplicate_key(self):
         """POSTing an already existing key should result in 409, not 422.

--- a/eve_sqlalchemy/tests/put.py
+++ b/eve_sqlalchemy/tests/put.py
@@ -12,6 +12,10 @@ from eve_sqlalchemy.tests import TestBase
 class TestPut(eve_put_tests.TestPut, TestBase):
 
     @pytest.mark.xfail(True, run=False, reason='not applicable to SQLAlchemy')
+    def test_put_dbref_subresource(self):
+        pass
+
+    @pytest.mark.xfail(True, run=False, reason='not applicable to SQLAlchemy')
     def test_allow_unknown(self):
         pass
 
@@ -157,7 +161,8 @@ class TestPut(eve_put_tests.TestPut, TestBase):
         raw_r = self.test_client.get(self.item_id_url)
         r, status = self.parse_response(raw_r)
         self.assert200(status)
-        self.assertEqual(raw_r.headers.get('ETag'),
+        # Since v0.7, ETag conform to RFC 7232-2.3 (see Eve#794)
+        self.assertEqual(raw_r.headers.get('ETag')[1:-1],
                          put_response[ETAG])
         if isinstance(fields, six.string_types):
             return r[fields]

--- a/setup.py
+++ b/setup.py
@@ -32,11 +32,9 @@ setup(
     packages=find_packages(),
     test_suite='eve_sqlalchemy.tests',
     install_requires=[
-        'Eve>=0.6,<0.7',
+        'Eve<0.8',
         'Flask-SQLAlchemy>=1.0,<2.999',
         'SQLAlchemy>=1.1',
-        # keep until pip properly resolves dependencies:
-        'Flask<0.11',
     ],
     tests_require=test_dependencies,
     extras_require={


### PR DESCRIPTION
(this PR is probably to be considered a WIP, for @dkellner to review)

The necessary premise is that I have (very) limited knowledge of
eve-sqlalchemy codebase. These changes might not be sufficient for
a Eve 0.7 compatible release of the eve-sqlalchemy extension.

I wanted to see what was preventing eve-sqlalchemy from running on Eve
0.7. As it turns out, there are no major obstacles. With this commit
all tests are passing with Eve<0.8, locally at least.

Next up would probably be a careful review of Eve 0.7 changelog, to see
what new features (or fixes) need to be specifically addressed here.